### PR TITLE
Add handy script to configure git to use ansible-vault-merge driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@ This is my git config and ansible-vault merge driver, handy for fixing vault con
 
 ### How to set this up 
 
-* Copy `.gitconfig` and `.gitattributes` to your home dir;
-* Make sure the `ansible-vault-merge` is executable;
-* Check the path for `ansible-vault-merge` in your `.gitconfig` to point to the right script;
-* Review and add your name/email or other custom config in your `.gitconfig`
+* Manual steps
+	- Copy `.gitconfig` and `.gitattributes` to your home dir;
+	- Make sure the `ansible-vault-merge` is executable;
+	- Check the path for `ansible-vault-merge` in your `.gitconfig` to point to the right script;
+	- Review and add your name/email or other custom config in your `.gitconfig`
+* Scripted steps
+	- Navigate to project root folder
+	- Run `install.sh` script using `./install.sh`
 
 ### How to test if it's working
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Utility script used to configure .gitconfig and .gitattributes behind the scene
+# The script will automatically add to .gitconfig the follwing bit if any of the following tags was not previously added
+#
+# [merge "ansible-vault"]
+#    name = ansible-vault merge driver
+#    driver = ${SCRIPT_PATH}/ansible-vault-merge %O %A %B %P
+# [diff "vault"]
+#    textconv = ansible-vault view
+#    cachetextconv = false
+# [diff "ansible-vault"]
+#    textconv = ansible-vault view
+#    cachetextconv = false
+# It will also add to .gitattribute the following bit if was not previously added
+# *.vault diff=ansible-vault merge=ansible-vault
+#
+# Usage: ./install.sh from project root folder
+
+
+set -eo
+
+SCRIPT_PATH="$( pwd )"
+MERGE_SCRIPT_PATH="${SCRIPT_PATH}/ansible-vault-merge"
+
+echo "Checking ${MERGE_SCRIPT_PATH} file"
+if [[ ! -f "${MERGE_SCRIPT_PATH}" ]]; then
+	echo "ansible-vault-merge script not found in path ${MERGE_SCRIPT_PATH}"
+	exit 1
+fi
+
+pushd ~/
+
+echo "Adding attributesfile property in `pwd`/.gitconfig"
+if ! grep "attributesfile" .gitconfig ; then
+	sed -i -E 's/\[core\]/\[core\] \
+	attributesfile = ~\/.gitattributes/g' .gitconfig 
+fi
+
+read -d '' GIT_CONFIG_CONTENT << EOM || true
+[merge "ansible-vault"]
+    name = ansible-vault merge driver
+    driver = ${SCRIPT_PATH}/ansible-vault-merge %O %A %B %P
+[diff "vault"]
+    textconv = ansible-vault view
+    cachetextconv = false
+[diff "ansible-vault"]
+    textconv = ansible-vault view
+    cachetextconv = false
+EOM
+
+read -d '' GIT_ATTR_CONTENT << EOM || true
+*.vault diff=ansible-vault merge=ansible-vault
+EOM
+
+echo "Checking if `pwd`/.gitconfig was previous configured"
+if ! grep -E "(?:merge \"ansible-vault\"|diff \"vault\"|diff \"ansible-vault\")" .gitconfig ; then
+	echo "Configuring `pwd`/.gitconfig"
+	echo "$GIT_CONFIG_CONTENT" | tee -a .gitconfig
+fi
+
+echo "Checking if `pwd`/.gitattributes was previous configured"
+if ! grep "${GIT_ATTR_CONTENT}" .gitattributes ; then
+	echo "Configuring `pwd`/.gitattributes"
+	echo "$GIT_ATTR_CONTENT" | tee -a .gitattributes
+fi

--- a/install.sh
+++ b/install.sh
@@ -23,16 +23,18 @@ set -eo
 SCRIPT_PATH="$( pwd )"
 MERGE_SCRIPT_PATH="${SCRIPT_PATH}/ansible-vault-merge"
 
+echo "=================================="
 echo "Checking ${MERGE_SCRIPT_PATH} file"
 if [[ ! -f "${MERGE_SCRIPT_PATH}" ]]; then
 	echo "ansible-vault-merge script not found in path ${MERGE_SCRIPT_PATH}"
 	exit 1
 fi
+echo "${MERGE_SCRIPT_PATH} already exists"
 
 pushd ~/
 
-echo "Adding attributesfile property in `pwd`/.gitconfig"
-if ! grep "attributesfile" .gitconfig ; then
+echo "Adding attributesfile property in `pwd`/.gitconfig if not exists"
+if ! grep -q "attributesfile" .gitconfig ; then
 	sed -i -E 's/\[core\]/\[core\] \
 	attributesfile = ~\/.gitattributes/g' .gitconfig 
 fi
@@ -54,13 +56,14 @@ read -d '' GIT_ATTR_CONTENT << EOM || true
 EOM
 
 echo "Checking if `pwd`/.gitconfig was previous configured"
-if ! grep -E "(?:merge \"ansible-vault\"|diff \"vault\"|diff \"ansible-vault\")" .gitconfig ; then
+if ! grep -q -E "(?:merge \"ansible-vault\"|diff \"vault\"|diff \"ansible-vault\")" .gitconfig ; then
 	echo "Configuring `pwd`/.gitconfig"
 	echo "$GIT_CONFIG_CONTENT" | tee -a .gitconfig
 fi
 
 echo "Checking if `pwd`/.gitattributes was previous configured"
-if ! grep "${GIT_ATTR_CONTENT}" .gitattributes ; then
+if ! grep -q "${GIT_ATTR_CONTENT}" .gitattributes ; then
 	echo "Configuring `pwd`/.gitattributes"
 	echo "$GIT_ATTR_CONTENT" | tee -a .gitattributes
 fi
+echo "=================================="


### PR DESCRIPTION
Add bash script to get rid of manual config steps. The script adds the required config in .gitconfig and .gitattributes files